### PR TITLE
Fix for Gleam 0.26

### DIFF
--- a/manifest.toml
+++ b/manifest.toml
@@ -2,8 +2,8 @@
 # You typically do not need to edit this file
 
 packages = [
-  { name = "gleam_stdlib", version = "0.25.0", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "AD0F89928E0B919C8F8EDF640484633B28DBF88630A9E6AE504617A3E3E5B9A2" },
-  { name = "gleeunit", version = "0.7.2", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "5F4FBED3E93CDEDB0570D30E9DECB7058C2D327996B78BB2D245C739C7136010" },
+  { name = "gleam_stdlib", version = "0.26.1", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "B17BBE8A78F3909D93BCC6C24F531673A7E328A61F24222EB1E58D0A7552B1FE" },
+  { name = "gleeunit", version = "0.10.1", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "ECEA2DE4BE6528D36AFE74F42A21CDF99966EC36D7F25DEB34D47DD0F7977BAF" },
 ]
 
 [requirements]

--- a/src/nibble/pratt.gleam
+++ b/src/nibble/pratt.gleam
@@ -25,7 +25,7 @@ pub opaque type Operator(a, ctx) {
 pub fn expression(
     one_of first: List(fn (Config(a, ctx)) -> Parser(a, ctx)),
     and_then_one_of then: List(Operator(a, ctx)),
-    spaces: Parser(Nil, ctx)
+    spaces_parser spaces: Parser(Nil, ctx)
 ) -> Parser(a, ctx) {
     let config = Config(first, then, spaces)
     sub_expression(config, 0)

--- a/src/nibble/pratt.gleam
+++ b/src/nibble/pratt.gleam
@@ -25,7 +25,7 @@ pub opaque type Operator(a, ctx) {
 pub fn expression(
     one_of first: List(fn (Config(a, ctx)) -> Parser(a, ctx)),
     and_then_one_of then: List(Operator(a, ctx)),
-    spaces_parser spaces: Parser(Nil, ctx)
+    dropping spaces: Parser(Nil, ctx)
 ) -> Parser(a, ctx) {
     let config = Config(first, then, spaces)
     sub_expression(config, 0)


### PR DESCRIPTION
Honestly I don't know what the name should be, so feel free to suggest another name. Without this label, the project won't compile on 0.26.