### PR TITLE
Update for Gleam 0.28

### DIFF
--- a/manifest.toml
+++ b/manifest.toml
@@ -2,7 +2,7 @@
 # You typically do not need to edit this file
 
 packages = [
-  { name = "gleam_stdlib", version = "0.26.1", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "B17BBE8A78F3909D93BCC6C24F531673A7E328A61F24222EB1E58D0A7552B1FE" },
+  { name = "gleam_stdlib", version = "0.28.1", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "73F0A89FADE5022CBEF6D6C3551F9ADCE7054AFCE0CB1DC4C6D5AB4CA62D0111" },
   { name = "gleeunit", version = "0.10.1", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "ECEA2DE4BE6528D36AFE74F42A21CDF99966EC36D7F25DEB34D47DD0F7977BAF" },
 ]
 

--- a/src/nibble.gleam
+++ b/src/nibble.gleam
@@ -251,7 +251,7 @@ pub fn int() -> Parser(Int, ctx) {
   // We can make the following assertion because we know our parser will
   // only consume digits, and is guaranteed to have at least one.
   |> map(fn(digits) {
-    assert Ok(int) = int.parse(digits)
+    let assert Ok(int) = int.parse(digits)
     int
   })
 }
@@ -268,7 +268,7 @@ pub fn float() -> Parser(Float, ctx) {
   // We can make the following assertion because we know our parser will
   // only consume digits, and is guaranteed to have at least one.
   |> map(fn(digits) {
-    assert Ok(float) = float.parse(digits)
+    let assert Ok(float) = float.parse(digits)
     float
   })
 }


### PR DESCRIPTION
This compiles on Gleam 0.28.

I guess if you wanted 0.27+, we could update `manifest.toml` to 0.27 stdlib. Let me know.